### PR TITLE
Add registry url to publish to NPM

### DIFF
--- a/.github/workflows/x-publish-npm.yml
+++ b/.github/workflows/x-publish-npm.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version: 16
           check-latest: true
+          registry-url: https://registry.npmjs.org
 
       - name: Download tarball
         run: gh release download ${{ inputs.tag }} --repo ${{ secrets.GH_ORG }}/${{ matrix.repository }}


### PR DESCRIPTION
Adds the [`registry-url`](https://github.com/actions/setup-node/blob/5b949b50c3461bbcd5a540b150c368278160234a/action.yml#L17-L18) option to the setup of Node.js when publishing to NPM. This created the correct config file needed for the publish to happen.