### PR TITLE
Temporary disable steps in 19 that passed the first time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,58 +12,57 @@ concurrency: rel-${{ github.ref }}
 
 jobs:
 
-  create-tags:
-    name: Create tags
-    uses: ./.github/workflows/x-create-tags.yml
-    with:
-      tag: ${{ github.event.inputs.version }}
-      branch: ${{ github.event.inputs.branch }}
-      set-versions: true
-    secrets:
-      GH_ORG: ${{ secrets.GH_ORG }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+#  create-tags:
+#    name: Create tags
+#    uses: ./.github/workflows/x-create-tags.yml
+#    with:
+#      tag: ${{ github.event.inputs.version }}
+#      branch: ${{ github.event.inputs.branch }}
+#      set-versions: true
+#    secrets:
+#      GH_ORG: ${{ secrets.GH_ORG }}
+#      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-  create-gh-releases:
-    name: Create Github releases
-    needs: [create-tags]
-    uses: ./.github/workflows/x-create-gh-releases.yml
-    with:
-      tag: ${{ github.event.inputs.version }}
-      prerelease: false
-    secrets:
-      GH_ORG: ${{ secrets.GH_ORG }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+#  create-gh-releases:
+#    name: Create Github releases
+#    needs: [create-tags]
+#    uses: ./.github/workflows/x-create-gh-releases.yml
+#    with:
+#      tag: ${{ github.event.inputs.version }}
+#      prerelease: false
+#    secrets:
+#      GH_ORG: ${{ secrets.GH_ORG }}
+#      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-  keycloak-nodejs-admin:
-    name: Keycloak Node.js Admin Client
-    needs: [create-tags, create-gh-releases]
-    uses: ./.github/workflows/x-keycloak-nodejs-admin.yml
-    with:
-      tag: ${{ github.event.inputs.version }}
-      version: ${{ github.event.inputs.version }}
-    secrets:
-      GH_ORG: ${{ secrets.GH_ORG }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+#  keycloak-nodejs-admin:
+#    name: Keycloak Node.js Admin Client
+#    needs: [create-tags, create-gh-releases]
+#    uses: ./.github/workflows/x-keycloak-nodejs-admin.yml
+#    with:
+#      tag: ${{ github.event.inputs.version }}
+#      version: ${{ github.event.inputs.version }}
+#    secrets:
+#      GH_ORG: ${{ secrets.GH_ORG }}
+#      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-  keycloak-admin-console:
-    name: Keycloak Admin Console
-    needs: [create-tags,keycloak-nodejs-admin]
-    uses: ./.github/workflows/x-keycloak-admin-console.yml
-    with:
-      version: ${{ github.event.inputs.version }}
-      tag: ${{ github.event.inputs.version }}
-    secrets:
-      GH_ORG: ${{ secrets.GH_ORG }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      MVN_URL: ${{ secrets.MVN_RELEASES_URL }}
-      MVN_USERNAME: ${{ secrets.MVN_USERNAME }}
-      MVN_TOKEN: ${{ secrets.MVN_TOKEN }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+#  keycloak-admin-console:
+#    name: Keycloak Admin Console
+#    needs: [create-tags,keycloak-nodejs-admin]
+#    uses: ./.github/workflows/x-keycloak-admin-console.yml
+#    with:
+#      version: ${{ github.event.inputs.version }}
+#      tag: ${{ github.event.inputs.version }}
+#    secrets:
+#      GH_ORG: ${{ secrets.GH_ORG }}
+#      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+#      MVN_URL: ${{ secrets.MVN_RELEASES_URL }}
+#      MVN_USERNAME: ${{ secrets.MVN_USERNAME }}
+#      MVN_TOKEN: ${{ secrets.MVN_TOKEN }}
+#      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+#      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
   keycloak:
     name: Keycloak
-    needs: [create-tags, create-gh-releases, keycloak-admin-console]
     uses: ./.github/workflows/x-keycloak.yml
     with:
       version: ${{ github.event.inputs.version }}
@@ -79,7 +78,7 @@ jobs:
 
   keycloak-container:
     name: Keycloak Container
-    needs: [create-tags,keycloak]
+    needs: [keycloak]
     uses: ./.github/workflows/x-keycloak-container.yml
     with:
       version: ${{ github.event.inputs.version }}
@@ -93,7 +92,7 @@ jobs:
 
   keycloak-operator:
     name: Keycloak Operator
-    needs: [create-tags,keycloak-container]
+    needs: [keycloak-container]
     uses: ./.github/workflows/x-keycloak-operator.yml
     with:
       version: ${{ github.event.inputs.version }}
@@ -110,7 +109,6 @@ jobs:
 
   keycloak-documentation:
     name: Keycloak Documentation
-    needs: [create-tags, create-gh-releases]
     uses: ./.github/workflows/x-keycloak-documentation.yml
     with:
       version: ${{ github.event.inputs.version }}
@@ -121,7 +119,7 @@ jobs:
 
   keycloak-quickstarts:
     name: Keycloak QuickStarts
-    needs: [create-tags,keycloak]
+    needs: [keycloak]
     uses: ./.github/workflows/x-keycloak-quickstarts.yml
     with:
       tag: ${{ github.event.inputs.version }}
@@ -132,7 +130,7 @@ jobs:
 
   publish-gh-releases:
     name: Publish releases
-    needs: [keycloak, keycloak-documentation, keycloak-nodejs-admin]
+    needs: [keycloak, keycloak-documentation]
     uses: ./.github/workflows/x-publish-gh-releases.yml
     with:
       tag: ${{ github.event.inputs.version }}
@@ -140,13 +138,13 @@ jobs:
       GH_ORG: ${{ secrets.GH_ORG }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-  publish-npm:
-    name: Publish NPM packages
-    needs: [keycloak-nodejs-admin]
-    uses: ./.github/workflows/x-publish-npm.yml
-    with:
-      tag: ${{ github.event.inputs.version }}
-    secrets:
-      GH_ORG: ${{ secrets.GH_ORG }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+#  publish-npm:
+#    name: Publish NPM packages
+#    needs: [keycloak-nodejs-admin]
+#    uses: ./.github/workflows/x-publish-npm.yml
+#    with:
+#      tag: ${{ github.event.inputs.version }}
+#    secrets:
+#      GH_ORG: ${{ secrets.GH_ORG }}
+#      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+#      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,15 +107,15 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
-  keycloak-documentation:
-    name: Keycloak Documentation
-    uses: ./.github/workflows/x-keycloak-documentation.yml
-    with:
-      version: ${{ github.event.inputs.version }}
-      tag: ${{ github.event.inputs.version }}
-    secrets:
-      GH_ORG: ${{ secrets.GH_ORG }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+#  keycloak-documentation:
+#    name: Keycloak Documentation
+#    uses: ./.github/workflows/x-keycloak-documentation.yml
+#    with:
+#      version: ${{ github.event.inputs.version }}
+#      tag: ${{ github.event.inputs.version }}
+#    secrets:
+#      GH_ORG: ${{ secrets.GH_ORG }}
+#      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
   keycloak-quickstarts:
     name: Keycloak QuickStarts
@@ -130,7 +130,7 @@ jobs:
 
   publish-gh-releases:
     name: Publish releases
-    needs: [keycloak, keycloak-documentation]
+    needs: [keycloak]
     uses: ./.github/workflows/x-publish-gh-releases.yml
     with:
       tag: ${{ github.event.inputs.version }}


### PR DESCRIPTION
The Node.js admin client and admin ui was released and published, so we need to disable some steps before retrying the release job again.