### PR TITLE
Overwrite artifacts in nightly release instead of deleting release

### DIFF
--- a/.github/workflows/x-create-gh-releases.yml
+++ b/.github/workflows/x-create-gh-releases.yml
@@ -37,9 +37,6 @@ jobs:
             fi
           )
 
-      - name: Delete existing release
-        if: steps.release-exists.outputs.exists == 'true'
-        run: gh release delete ${{ inputs.tag }} --repo ${{ secrets.GH_ORG }}/${{ matrix.repository }} --yes
-
       - name: Create a release
+        if: steps.release-exists.outputs.exists == 'false'
         run: gh release create ${{ inputs.tag }} --repo ${{ secrets.GH_ORG }}/${{ matrix.repository }} --title ${{ inputs.tag }} --draft ${{ inputs.prerelease && '--prerelease' || '' }}

--- a/.github/workflows/x-keycloak-documentation.yml
+++ b/.github/workflows/x-keycloak-documentation.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Upload to GitHub Releases
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: gh release upload ${{ inputs.tag }} ./dist/target/keycloak-documentation-${{ inputs.version }}.zip
+        run: gh release upload --clobber ${{ inputs.tag }} ./dist/target/keycloak-documentation-${{ inputs.version }}.zip

--- a/.github/workflows/x-keycloak-nodejs-admin.yml
+++ b/.github/workflows/x-keycloak-nodejs-admin.yml
@@ -49,6 +49,6 @@ jobs:
           mv -T *.tgz keycloak-nodejs-admin-client.tgz
 
       - name: Upload to GitHub Releases
-        run: gh release upload ${{ inputs.tag }} keycloak-nodejs-admin-client.tgz
+        run: gh release upload --clobber ${{ inputs.tag }} keycloak-nodejs-admin-client.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/x-keycloak.yml
+++ b/.github/workflows/x-keycloak.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Upload to GitHub Releases
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: gh release upload ${{ inputs.tag }} ./distribution/downloads/target/${{ inputs.version }}/*
+        run: gh release upload --clobber ${{ inputs.tag }} ./distribution/downloads/target/${{ inputs.version }}/*


### PR DESCRIPTION
This will stop deleting the nightly release and instead simply overwrite files if the release already exists.

Closes #47
Closes #50 
