### PR TITLE
Release process for OperatorHub

### DIFF
--- a/.github/env/keycloak-rel
+++ b/.github/env/keycloak-rel
@@ -5,3 +5,8 @@ mvn-snapshots-url=https://s01.oss.sonatype.org/content/repositories/snapshots/
 
 quay-org=keycloak
 docker-org=keycloak
+
+operator-publish-repo-org=keycloak-bot
+
+community-operators-repo=https://github.com/k8s-operatorhub/community-operators.git
+prod-operators-repo=https://github.com/redhat-openshift-ecosystem/community-operators-prod.git

--- a/.github/env/keycloak-rel-testing
+++ b/.github/env/keycloak-rel-testing
@@ -5,3 +5,8 @@ mvn-snapshots-url=https://maven.pkg.github.com/keycloak-rel-testing/maven
 
 quay-org=keycloaktesting
 docker-org=keycloaktesting
+
+operator-publish-repo-org=keycloak-rel-testing
+
+community-operators-repo=https://github.com/keycloak-rel-testing/community-operators.git
+prod-operators-repo=https://github.com/keycloak-rel-testing/community-operators-prod.git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: 'Keycloak branch'
         required: true
       version:
+        description: 'New version'
+        required: true
+      previous-version:
+        description: 'Old version'
         required: true
 
 concurrency: rel-${{ github.ref }}
@@ -22,6 +27,7 @@ jobs:
       - run: |
           echo "Version: ${{ inputs.version }}  " >> $GITHUB_STEP_SUMMARY
           echo "Release branch: ${{ inputs.branch }}  " >> $GITHUB_STEP_SUMMARY
+          echo "Previous Keycloak version: ${{ inputs.previous-version }}  " >> $GITHUB_STEP_SUMMARY
           echo "Workflow branch: ${{ github.ref_name }}  " >> $GITHUB_STEP_SUMMARY
 
   env:
@@ -144,3 +150,21 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-keycloak-operator-hub:
+    name: Publish Keycloak Operator to OperatorHub
+    needs: [ env, create-tags, keycloak-operator ]
+    uses: ./.github/workflows/x-keycloak-operator-hub-publish.yml
+    with:
+      gh-org: ${{ needs.env.outputs.gh-org }}
+      quay-org: ${{ needs.env.outputs.quay-org }}
+      operator-publish-repo-org: ${{ needs.env.outputs.operator-publish-repo-org }}
+      mvn-url: ${{ needs.env.outputs.mvn-releases-url }}
+      version: ${{ github.event.inputs.version }}
+      previous-version: ${{ github.event.inputs.previous-version }}
+      community-operators-repo: ${{ needs.env.outputs.community-operators-repo }}
+      prod-operators-repo: ${{ needs.env.outputs.prod-operators-repo }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      MVN_USERNAME: ${{ secrets.MVN_USERNAME }}
+      MVN_TOKEN: ${{ secrets.MVN_TOKEN }}

--- a/.github/workflows/x-env.yml
+++ b/.github/workflows/x-env.yml
@@ -15,9 +15,24 @@ on:
       quay-org:
         description: "Quay Organization"
         value: ${{ jobs.env.outputs.quay-org }}
+      operator-publish-repo-org:
+        description: "Target organization of fork for pushing necessary changes"
+        value: ${{ jobs.env.outputs.operator-publish-repo-org }}
+      operator-publish-author-name:
+        description: "Name of an author who creates PR for particular repositories"
+        value: ${{ jobs.env.outputs.operator-publish-author-name }}
+      operator-publish-author-email:
+        description: "Email of an author who creates PR for particular repositories"
+        value: ${{ jobs.env.outputs.operator-publish-author-email }}
       docker-org:
         description: "Docker Organization"
         value: ${{ jobs.env.outputs.docker-org }}
+      community-operators-repo:
+        description: "Community operators repository"
+        value: ${{ jobs.env.outputs.community-operators-repo }}
+      prod-operators-repo:
+        description: "Product operators repository"
+        value: ${{ jobs.env.outputs.prod-operators-repo }}
 
 defaults:
   run:
@@ -31,7 +46,12 @@ jobs:
       mvn-releases-url: ${{ env.mvn-releases-url }}
       mvn-snapshots-url: ${{ env.mvn-snapshots-url }}
       quay-org: ${{ env.quay-org }}
+      operator-publish-repo-org: ${{ env.operator-publish-repo-org }}
+      operator-publish-author-name: ${{ env.operator-publish-author-name }}
+      operator-publish-author-email: ${{ env.operator-publish-author-email }}
       docker-org: ${{ env.docker-org }}
+      community-operators-repo: ${{ env.community-operators-repo }}
+      prod-operators-repo: ${{ env.prod-operators-repo }}
     steps:
       - uses: actions/checkout@v3
       - id: load-env

--- a/.github/workflows/x-keycloak-operator-hub-publish.yml
+++ b/.github/workflows/x-keycloak-operator-hub-publish.yml
@@ -1,0 +1,180 @@
+name: X Keycloak Operator Hub publish
+
+on:
+  workflow_call:
+    inputs:
+      gh-org:
+        required: true
+        type: string
+      quay-org:
+        required: true
+        type: string
+      operator-publish-repo-org:
+        required: true
+        type: string
+      community-operators-repo:
+        required: true
+        type: string
+      prod-operators-repo:
+        required: true
+        type: string
+      mvn-url:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      previous-version:
+        required: true
+        type: string
+    secrets:
+      GH_TOKEN:
+        required: true
+      MVN_USERNAME:
+        required: true
+      MVN_TOKEN:
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          repository: keycloak/keycloak
+          ref: ${{ inputs.version }}
+          path: keycloak
+
+      - name: Build
+        env:
+          MAVEN_ID: kc-rel-repository
+          MAVEN_URL: ${{ inputs.mvn-url }}
+          MAVEN_USERNAME: ${{ secrets.MVN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MVN_TOKEN }}
+        working-directory: keycloak
+        run: |
+          ./mvnw clean package \
+              -s ./.github/mvn-rel-settings.xml \
+              -f operator/pom.xml \
+              -DskipTests
+
+      - name: Install Yq
+        working-directory: keycloak
+        run: sudo snap install yq
+
+      - name: Create OLM Bundle
+        working-directory: keycloak
+        run: |
+          cd operator && ./scripts/create-olm-bundle.sh ${{ inputs.version }} ${{ inputs.previous-version }} quay.io/${{ inputs.quay-org }}/keycloak-operator
+
+      - name: Compress OLM Bundle
+        working-directory: keycloak
+        run: |
+          tar --use-compress-program zstd -cf olm-bundle-keycloak.tzst \
+          --exclude '*.tar.gz' \
+          -C operator/olm/${{ inputs.version }} .
+
+      - name: Upload Keycloak OLM bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: olm-bundle-keycloak.tzst
+          path: keycloak/olm-bundle-keycloak.tzst
+          if-no-files-found: error
+          retention-days: 1
+
+  release-community:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Clone community-operators
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.operator-publish-repo-org }}/community-operators
+          path: community-operators
+
+      - name: Download Keycloak OLM bundle
+        uses: actions/download-artifact@v3
+        with:
+          path: community-operators
+          name: olm-bundle-keycloak.tzst
+
+      - name: Push changes to particular Community operators fork
+        working-directory: community-operators
+        run: |
+          git remote add upstream ${{ inputs.community-operators-repo }}
+          git fetch upstream
+          
+          git checkout upstream/main -B releases/${{ inputs.version }}
+          
+          mkdir -p operators/keycloak-operator/${{ inputs.version }}
+          tar -C operators/keycloak-operator/${{ inputs.version }} --use-compress-program="zstd -d" -xf olm-bundle-keycloak.tzst
+          
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          
+          git add .
+          git commit -s -m "Bump Keycloak operator to ${{ inputs.version }}"
+          
+          git push origin HEAD
+
+      - name: Automatic Community PR opening
+        working-directory: community-operators
+        run: |
+          gh pr create --title "Bump Keycloak operator to ${{ inputs.version }}" --fill --repo ${{ inputs.community-operators-repo }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  release-product:
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    steps:
+      - name: Clone community-operators-prod
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.operator-publish-repo-org }}/community-operators-prod
+          path: community-operators-prod
+
+      - name: Download Keycloak OLM bundle
+        uses: actions/download-artifact@v3
+        with:
+          path: community-operators-prod
+          name: olm-bundle-keycloak.tzst
+
+      - name: Push changes to particular Prod operators fork
+        working-directory: community-operators-prod
+        run: |
+          git remote add upstream ${{ inputs.prod-operators-repo }}
+          git fetch upstream
+          
+          git checkout upstream/main -B releases/${{ inputs.version }}
+          
+          mkdir -p operators/keycloak-operator/${{ inputs.version }}
+          tar -C operators/keycloak-operator/${{ inputs.version }} --use-compress-program="zstd -d" -xf olm-bundle-keycloak.tzst
+          
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          
+          git add .
+          git commit -s -m "Bump Keycloak operator to ${{ inputs.version }}"
+          
+          git push origin HEAD  
+
+      - name: Automatic Prod PR opening
+        working-directory: community-operators-prod
+        run: |
+          gh pr create --title "Bump Keycloak operator to ${{ inputs.version }}" --fill --repo ${{ inputs.prod-operators-repo }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/10438

Testing is still in progress.[1]

In the end, it'd be maybe better to explicitly set the previous version of Keycloak required for OLM settings, as @vmuzikar suggested. 

Testing progress:
Still struggling with used credentials for the GHA bot as it's not possible to push changes to particular branches[2]. I've changed the fork repos to `keycloak-rel-testing` organization in order to try if it's really an issue with the credentials. As for the `keycloak-rel-testing`, it should be possible to push some commits to repositories included in a particular organization (due to the Workflow settings).

[1] https://github.com/keycloak-rel-testing/keycloak-rel/actions/runs/3337653430

[2] https://github.com/keycloak-rel/keycloak-rel/compare/main...keycloak-rel-testing:keycloak-rel:operatorhub#diff-732921da58cc64279cba94408ed726519ab0ed149a441c33ce515586dded5f22R106 
