### PR TITLE
Add fallback for `--dry-run` condition when publishing to NPM

### DIFF
--- a/.github/workflows/x-publish-npm.yml
+++ b/.github/workflows/x-publish-npm.yml
@@ -67,7 +67,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Publish to NPM
-        run: npm publish --ignore-scripts ${{ inputs.gh-org != 'keycloak' && ' --dry-run' }}
+        run: npm publish --ignore-scripts ${{ inputs.gh-org != 'keycloak' && ' --dry-run' || '' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Cherry-picks #73 into the release.