### PR TITLE
Add Keycloak UI to releases

### DIFF
--- a/.github/workflows/branch-create.yml
+++ b/.github/workflows/branch-create.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         repository:
           - keycloak
-          - keycloak-admin-ui
+          - keycloak-ui
           - keycloak-documentation
           - keycloak-nodejs-admin-client
           - keycloak-nodejs-connect

--- a/.github/workflows/branch-delete.yml
+++ b/.github/workflows/branch-delete.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         repository:
           - keycloak
-          - keycloak-admin-ui
+          - keycloak-ui
           - keycloak-documentation
           - keycloak-nodejs-admin-client
           - keycloak-nodejs-connect

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         repository:
           - keycloak
-          - keycloak-admin-ui
+          - keycloak-ui
           - keycloak-documentation
           - keycloak-nodejs-admin-client
           - keycloak-nodejs-connect

--- a/.github/workflows/x-create-gh-releases.yml
+++ b/.github/workflows/x-create-gh-releases.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         repository:
           - keycloak
+          - keycloak-ui
           - keycloak-documentation
           - keycloak-nodejs-admin-client
           - keycloak-nodejs-connect

--- a/.github/workflows/x-create-tags.yml
+++ b/.github/workflows/x-create-tags.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         repository:
           - keycloak
-          - keycloak-admin-ui
+          - keycloak-ui
           - keycloak-documentation
           - keycloak-nodejs-admin-client
           - keycloak-nodejs-connect
@@ -71,7 +71,7 @@ jobs:
     steps:
       - run: |
           echo "https://github.com/${{ inputs.gh-org }}/keycloak/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
-          echo "https://github.com/${{ inputs.gh-org }}/keycloak-admin-ui/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
+          echo "https://github.com/${{ inputs.gh-org }}/keycloak-ui/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
           echo "https://github.com/${{ inputs.gh-org }}/keycloak-documentation/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
           echo "https://github.com/${{ inputs.gh-org }}/keycloak-nodejs-admin-client/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
           echo "https://github.com/${{ inputs.gh-org }}/keycloak-quickstarts/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/x-keycloak-admin-console.yml
+++ b/.github/workflows/x-keycloak-admin-console.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3.0.0
         with:
-          repository: '${{ inputs.gh-org }}/keycloak-admin-ui'
+          repository: '${{ inputs.gh-org }}/keycloak-ui'
           token: ${{ secrets.GH_TOKEN }}
           ref: ${{ inputs.tag }}
 

--- a/.github/workflows/x-publish-gh-releases.yml
+++ b/.github/workflows/x-publish-gh-releases.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         repository:
           - keycloak
+          - keycloak-ui
           - keycloak-documentation
           - keycloak-nodejs-admin-client
           - keycloak-nodejs-connect
@@ -40,6 +41,7 @@ jobs:
     steps:
       - run: |
           echo "https://github.com/${{ inputs.gh-org }}/keycloak/releases/tag/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
+          echo "https://github.com/${{ inputs.gh-org }}/keycloak-ui/releases/tag/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
           echo "https://github.com/${{ inputs.gh-org }}/keycloak-documentation/releases/tag/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
           echo "https://github.com/${{ inputs.gh-org }}/keycloak-nodejs-admin-client/releases/tag/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
           echo "https://github.com/${{ inputs.gh-org }}/keycloak-nodejs-connect/releases/tag/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Tag name is {version} (for example `19.0.0`), or `nightly` for nightly releases.
 |Repo|Main|Test|
 |----|----|----|
 |keycloak|https://github.com/keycloak/keycloak|https://github.com/keycloak-rel-testing/keycloak|
-|keycloak-admin-ui|https://github.com/keycloak/keycloak-admin-ui|https://github.com/keycloak-rel-testing/keycloak-admin-ui|
+|keycloak-ui|https://github.com/keycloak/keycloak-ui|https://github.com/keycloak-rel-testing/keycloak-ui|
 |keycloak|https://github.com/keycloak/keycloak-documentation|https://github.com/keycloak-rel-testing/keycloak-documentation|
 |keycloak-nodejs-admin-client|https://github.com/keycloak/keycloak-nodejs-admin-client|https://github.com/keycloak-rel-testing/keycloak-nodejs-admin-client|
 |keycloak-quickstarts|https://github.com/keycloak/keycloak-quickstarts|https://github.com/keycloak-rel-testing/keycloak-quickstarts|


### PR DESCRIPTION
Previously no releases were created on GitHub for the Keycloak UI repository. This PR adds it to the workflows to create and publish releases on the GitHub repo.

This also renames the `keycloak-admin-ui` repo to `keycloak-ui`, as it now contains more than just the Admin UI. This will require the repositories to be renamed in the release organisations as well.