### PR TITLE
Use a valid SemVer format for the SNAPSHOT version

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/x-keycloak-admin-console.yml
     with:
       gh-org: ${{ needs.env.outputs.gh-org }}
-      version: 999-SNAPSHOT
+      version: 999.0.0-SNAPSHOT
       tag: nightly
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
     with:
       gh-org: ${{ needs.env.outputs.gh-org }}
       mvn-url: ${{ needs.env.outputs.mvn-snapshots-url }}
-      version: 999-SNAPSHOT
+      version: 999.0.0-SNAPSHOT
       tag: nightly
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
       gh-org: ${{ needs.env.outputs.gh-org }}
       quay-org: ${{ needs.env.outputs.quay-org }}
       docker-org: ${{ needs.env.outputs.docker-org }}
-      version: 999-SNAPSHOT
+      version: 999.0.0-SNAPSHOT
       tag: nightly
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
       quay-org: ${{ needs.env.outputs.quay-org }}
       docker-org: ${{ needs.env.outputs.docker-org }}
       mvn-url: ${{ needs.env.outputs.mvn-snapshots-url }}
-      version: 999-SNAPSHOT
+      version: 999.0.0-SNAPSHOT
       tag: nightly
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -133,7 +133,7 @@ jobs:
     uses: ./.github/workflows/x-keycloak-documentation.yml
     with:
       gh-org: ${{ needs.env.outputs.gh-org }}
-      version: 999-SNAPSHOT
+      version: 999.0.0-SNAPSHOT
       tag: nightly
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Release name is {version} (for example `19.0.0`), or `nightly` for nightly relea
 
 ## Maven
 
-Nightly releases uses `999-SNAPSHOT` version. Maven artifacts are currently published to GitHub Packages for test releases, but plan is to stop doing this and only upload to GitHub releases.
+Nightly releases uses `999.0.0-SNAPSHOT` version. Maven artifacts are currently published to GitHub Packages for test releases, but plan is to stop doing this and only upload to GitHub releases.
 
 |Main - Release|Main - Nightly|Test|
 |--------------|--------------|----|


### PR DESCRIPTION
Changes the default version string from `999-SNAPSHOT` to `999.0.0-SNAPSHOT`. This makes it a valid version under the [Semantic Versioning](https://semver.org/) standard.

The motivation for this change is to make versioning interoperable between Maven and NPM, as the latter only allows for Semantic Versioning. This allows for simplification in the release process, as we no longer need to convert version numbers from one to the other.

For more information see https://github.com/keycloak/keycloak/issues/17335.