### PR TITLE
Remove deprecation step for Node.js Connect

### DIFF
--- a/.github/workflows/x-publish-npm.yml
+++ b/.github/workflows/x-publish-npm.yml
@@ -47,13 +47,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # TODO: Remove this once we stop supporting the Node.js Connect package.
-      - name: Deprecate package
-        if: inputs.gh-org == 'keycloak' && matrix.tarball == 'keycloak-nodejs-connect.tgz'
-        run: npm deprecate -f keycloak-connect "This package is deprecated and will be removed in the future. We will shortly provide more details on removal date, and recommended alternatives."
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   list-npm:
     name: Show NPM packages
     runs-on: ubuntu-latest


### PR DESCRIPTION
The NPM API [mistakenly thinks](https://github.com/keycloak-rel/keycloak-rel/actions/runs/5397857402/jobs/9803382635) that deprecating the package right after publishing is an intent to remove the package. This change removes the deprecation step for the Node.js Connect NPM package, as it's causing too many failures during the release.

Closes #93