### PR TITLE
Tweak OCI labels to be more correct and follow upstream

### DIFF
--- a/.github/workflows/x-keycloak-container.yml
+++ b/.github/workflows/x-keycloak-container.yml
@@ -68,6 +68,12 @@ jobs:
             type=semver,pattern={{version}},value=${{ inputs.tag }},enable=${{ inputs.tag != 'nightly' }}
             type=semver,pattern={{version}},value=${{ inputs.tag }}-${{ inputs.respin }},enable=${{ inputs.tag != 'nightly' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }},enable=${{ inputs.tag != 'nightly' }}
+          labels: |
+            org.opencontainers.image.title=Keycloak
+            org.opencontainers.image.url=https://keycloak.org
+            org.opencontainers.image.source=https://github.com/keycloak/keycloak
+            org.opencontainers.image.description=Open Source Identity and Access Management For Modern Applications and Services
+            org.opencontainers.image.documentation=https://keycloak.org/documentation
 
       - name: Login to Quay
         uses: docker/login-action@v1.14.1


### PR DESCRIPTION
Specifically I'm changing this so [Renovate](https://github.com/renovatebot/renovate) is able to look at the correct repo for changelog gathering. https://docs.renovatebot.com/modules/datasource/docker/

PR where it can't gather a changelog: https://github.com/MindTooth/renovate-gitlab-test/pull/10

Also, I've added an additional label for where to find the documentation.

Following https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys keys.

---

The current labels are not at all what I would expect from inspecting an upstream container image:
```
                "org.opencontainers.image.created": "2024-02-02T14:15:46.045Z",
                "org.opencontainers.image.description": "",
                "org.opencontainers.image.licenses": "Apache-2.0",
                "org.opencontainers.image.revision": "1e1a5a5199da598fe271ca313b7ba8880669fe25",
                "org.opencontainers.image.source": "https://github.com/keycloak-rel/keycloak-rel",
                "org.opencontainers.image.title": "keycloak-rel",
                "org.opencontainers.image.url": "https://github.com/keycloak-rel/keycloak-rel",
                "org.opencontainers.image.version": "23.0.6",
```

This change should fix this.  Please verify.