### PR TITLE
initial version of releasing the account-ui

### DIFF
--- a/.github/workflows/x-publish-npm.yml
+++ b/.github/workflows/x-publish-npm.yml
@@ -25,6 +25,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - tarball: keycloak-account-ui-${{ inputs.tag }}.tgz
+          - tarball: keycloak-ui-shared-${{ inputs.tag }}.tgz
           - tarball: keycloak-admin-client-${{ inputs.tag }}.tgz
           - tarball: keycloak-js-${{ inputs.tag }}.tgz
           - tarball: keycloak-nodejs-connect.tgz
@@ -55,4 +57,6 @@ jobs:
     steps:
       - run: |
           echo "https://www.npmjs.com/package/@keycloak/keycloak-admin-client/v/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
+          echo "https://www.npmjs.com/package/@keycloak/keycloak-account-ui/v/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
+          echo "https://www.npmjs.com/package/@keycloak/keycloak-ui-shared/v/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
           echo "https://www.npmjs.com/package/keycloak-js/v/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Not entirely sure how it all work, but something like this should be done to release the account ui as a package to npm. It needs to be build with the `LIB=true` so that it's a library that can be included instead of an webapp
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
