### PR TITLE
Operator ARM build

### DIFF
--- a/.github/workflows/x-keycloak-operator.yml
+++ b/.github/workflows/x-keycloak-operator.yml
@@ -97,28 +97,30 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build
+      - name: Build Operator
         env:
           MAVEN_ID: kc-rel-repository
           MAVEN_URL: ${{ inputs.mvn-url }}
           MAVEN_USERNAME: ${{ secrets.MVN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MVN_TOKEN }}
         working-directory: keycloak
-        # hardcoded Quay.io image coordinates here are used only for building the K8s YAML resources (where we use Quay and not Docker Hub)
         run: |
           ./mvnw -B clean package \
               -s ./.github/mvn-rel-settings.xml \
               -f operator/pom.xml \
               -DskipTests \
-              -Dquarkus.container-image.image=quay.io/${{ inputs.quay-org }}/keycloak-operator:${{ inputs.tag }} \
-              -Dquarkus.container-image.build=true \
               -Dkc.operator.keycloak.image=quay.io/${{ inputs.quay-org }}/keycloak:${{ inputs.tag }}
 
-      - name: Tag and push the operator images
-        working-directory: keycloak
-        run: |
-          echo "${{ steps.meta.outputs.tags }}" | xargs -I {} \
-            sh -c "docker tag quay.io/${{ inputs.quay-org }}/keycloak-operator:${{ inputs.tag }} {} && docker push {}"
+      - name: Build image and push
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: keycloak/operator
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            KEYCLOAK_VERSION=${{ inputs.version }}
 
       - name: Clone k8s resources repository
         uses: actions/checkout@v3.0.0


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/11820

What this does:
* Operator image is now multiarch – amd64 and arm64. This aligns it with the Keycloak server image.
* Image is no longer built via the Quarkus maven plugin but rather via Docker directly (through the GHA). This again aligns it with the Keycloak server image. This was required for the multiarch, multi tag build and easier to be done than using the Quarkus maven plugin.

Successful release run: https://github.com/keycloak-rel-testing/keycloak-rel/actions/runs/9016667542/job/24774942965
Image created: https://quay.io/repository/keycloaktesting/keycloak-operator?tab=tags