### PR TITLE
[26.2] Failed release process for OperatorHub - community

### DIFF
--- a/.github/workflows/x-keycloak-operator-hub-publish.yml
+++ b/.github/workflows/x-keycloak-operator-hub-publish.yml
@@ -108,7 +108,7 @@ jobs:
           fi
           
           if [[ "$prOpen" == "false" ]]; then
-            gh pr create --title "operator keycloak-operator (${{ inputs.version }})" --repo ${{ env.repository-url }} --base main -F docs/pull_request_template.md --head ${{ env.repository-org }}:${{ inputs.version }} -r ${{ env.reviewers }}
+            gh pr create --title "operator keycloak-operator (${{ inputs.version }})" --repo ${{ env.repository-url }} --base main -F docs/pull_request_template.md --head ${{ github.repository_owner }}:${{ inputs.version }} -r ${{ env.reviewers }}
           else
             echo "PR already exists, skipping..."
           fi


### PR DESCRIPTION
Closes #146

This should fix the issue, but we can't test it in the keycloak-rel-testing due to other issue with Maven credentials.