### PR TITLE
[operator] Disable automatic PR opening for OperatorHub

### DIFF
--- a/.github/workflows/x-keycloak-operator-hub-publish.yml
+++ b/.github/workflows/x-keycloak-operator-hub-publish.yml
@@ -59,7 +59,7 @@ jobs:
           echo "repository-org=$REPO_ORG" >> $GITHUB_ENV
           echo "repository-name=$REPO_NAME" >> $GITHUB_ENV
           echo "repository-url=https://github.com/$REPO_ORG/$REPO_NAME.git" >> $GITHUB_ENV
-          echo "reviewers=stianst,abstractj,vmuzikar,mabartos" >> $GITHUB_ENV
+          echo "reviewers=vmuzikar,mabartos,Pepo48,shawkins" >> $GITHUB_ENV
 
       - name: Clone community-operators
         uses: actions/checkout@v4
@@ -94,7 +94,8 @@ jobs:
 
       - name: Automatic PR opening
         working-directory: community-operators
-        # Once we are okay with the release process, remove reviewers
+        if: false # We disable automatic PR opening now as there are failures like: pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
+        # Once we are okay with the release process, remove reviewers -> EDIT: reviewers removed for now as users cannot be found
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
@@ -108,7 +109,7 @@ jobs:
           fi
           
           if [[ "$prOpen" == "false" ]]; then
-            gh pr create --title "operator keycloak-operator (${{ inputs.version }})" --repo ${{ env.repository-url }} --base main -F docs/pull_request_template.md --head ${{ github.repository_owner }}:${{ inputs.version }} -r ${{ env.reviewers }}
+            gh pr create --title "operator keycloak-operator (${{ inputs.version }})" --repo ${{ env.repository-url }} --base main -F docs/pull_request_template.md --head ${{ github.repository_owner }}:${{ inputs.version }}
           else
             echo "PR already exists, skipping..."
           fi


### PR DESCRIPTION
This disables the automatic PR opening for OperatorHub.

### Required change for releases

In order to at least push the bundle to the `keycloak-rel/community-operators` (and `-prod`), it is necessary to sync these forks with upstream versions:

- https://github.com/keycloak-rel/community-operators
- https://github.com/keycloak-rel/community-operators-prod

@stianst Could you please sync them? Can be easily done via the button 'Sync fork' in the repository:
<img width="448" height="208" alt="image" src="https://github.com/user-attachments/assets/29f41eb7-5d69-4c4f-84df-396cc0ded76f" />

There are some changes in the workflows for the upstream and it needs to be manually synced as the GH App pushing these changes does not have the permission `workflows: R/W`. It is the easiest approach that should work for now. We'll discuss a better future-proof approach later. 

The workflow step is successfully disabled, see: https://github.com/keycloak-rel-testing/keycloak-rel/actions/runs/17070622828

