### PR TITLE
Operator build is missing test dependency: org.keycloak:keycloak-admin-client-tests

### DIFF
--- a/.github/workflows/x-keycloak-operator.yml
+++ b/.github/workflows/x-keycloak-operator.yml
@@ -93,16 +93,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build Keycloak Core
-        working-directory: keycloak
-        run: ./mvnw -am -pl core install -DskipTests
-
       - name: Build Operator
         working-directory: keycloak
         # hardcoded Quay.io image coordinates here are used only for building the K8s YAML resources (where we use Quay and not Docker Hub)
         run: |
           ./mvnw -B clean package \
-              -f operator/pom.xml \
+              -am -pl operator -Doperator \
               -DskipTests \
               -Dquarkus.container-image.image=quay.io/${{ inputs.quay-org }}/keycloak-operator:${{ inputs.tag }} \
               -Dkc.operator.keycloak.image=quay.io/${{ inputs.quay-org }}/keycloak:${{ inputs.tag }}


### PR DESCRIPTION
Recent changes to operator require new dependency to be build for the operator release workflow.

Closes #178